### PR TITLE
Update babel-jest to version 24

### DIFF
--- a/js/.babelrc
+++ b/js/.babelrc
@@ -1,3 +1,3 @@
-{
-  "presets": ["env"]
+{ 
+  "presets": ["@babel/preset-env"] 
 }

--- a/js/package.json
+++ b/js/package.json
@@ -2,11 +2,12 @@
   "name": "name-normalizer",
   "version": "0.1.0",
   "devDependencies": {
-    "babel-jest": "^22.2.2",
-    "babel-preset-env": "^1.6.1",
-    "jest": "^22.2.2"
+    "@babel/preset-env": "^7.4.5",
+    "babel-jest": "^24.8.0",
+    "jest": "^24.8.0"
   },
   "scripts": {
     "test": "jest"
-  }
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
Great tutorial, very educational. I was not able to run the js tutorial with the current versions of babel-jest and jest. I have made these changes in the package.json.