### PR TITLE
. r Remove semicolon in import statement

### DIFF
--- a/kotlin-junit5/src/test/kotlin/AuthorNameNormalizerTest.kt
+++ b/kotlin-junit5/src/test/kotlin/AuthorNameNormalizerTest.kt
@@ -1,4 +1,4 @@
-import org.assertj.core.api.Assertions.*;
+import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 


### PR DESCRIPTION
A very minor edit to remove an unnecessary semicolon in an import statement in the test class.